### PR TITLE
Keep CRT effect visible in fullscreen

### DIFF
--- a/web-prototype/shared/fullscreen-overlay.js
+++ b/web-prototype/shared/fullscreen-overlay.js
@@ -1,0 +1,23 @@
+// Keep the same canvas (and WebGL context) when native fullscreen promotes
+// the game shell into the browser's top layer. The host owns no React children.
+export function mountFullscreenOverlay(host, document) {
+  const canvas = document.createElement("canvas");
+  canvas.id = "crt-viewport-canvas";
+  canvas.setAttribute("aria-hidden", "true");
+  host.appendChild(canvas);
+
+  function sync() {
+    const fullscreen = document.fullscreenElement || document.webkitFullscreenElement;
+    const parent = fullscreen?.matches(".game-surface-shell") ? fullscreen : host;
+    if (canvas.parentNode !== parent) parent.appendChild(canvas);
+  }
+
+  document.addEventListener("fullscreenchange", sync);
+  document.addEventListener("webkitfullscreenchange", sync);
+  sync();
+  return () => {
+    document.removeEventListener("fullscreenchange", sync);
+    document.removeEventListener("webkitfullscreenchange", sync);
+    canvas.remove();
+  };
+}

--- a/web-prototype/shared/fullscreen-overlay.test.js
+++ b/web-prototype/shared/fullscreen-overlay.test.js
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mountFullscreenOverlay } from "./fullscreen-overlay.js";
+
+function harness() {
+  const listeners = new Map();
+  const element = (shell = false) => ({
+    children: [],
+    setAttribute() {},
+    matches: (selector) => shell && selector === ".game-surface-shell",
+    appendChild(child) { child.remove(); this.children.push(child); child.parentNode = this; },
+    remove() { if (this.parentNode) this.parentNode.children = this.parentNode.children.filter((child) => child !== this); this.parentNode = null; },
+  });
+  const document = {
+    createElement: () => element(),
+    addEventListener: (name, fn) => listeners.set(name, fn),
+    removeEventListener: (name) => listeners.delete(name),
+  };
+  const host = element();
+  const cleanup = mountFullscreenOverlay(host, document);
+  return { document, host, canvas: host.children[0], shell: element(true), other: element(), listeners, cleanup };
+}
+
+for (const [property, event] of [["fullscreenElement", "fullscreenchange"], ["webkitFullscreenElement", "webkitfullscreenchange"]]) {
+  test(`${event} preserves the canvas across repeated enter/exit and cleans up`, () => {
+    const h = harness();
+    for (let i = 0; i < 2; i++) {
+      h.document[property] = h.shell;
+      h.listeners.get(event)();
+      assert.equal(h.canvas.parentNode, h.shell);
+      assert.deepEqual(h.shell.children, [h.canvas]);
+      h.document[property] = null;
+      h.listeners.get(event)();
+      assert.deepEqual(h.host.children, [h.canvas]);
+      assert.equal(h.shell.children.length, 0);
+    }
+    h.document[property] = h.shell;
+    h.listeners.get(event)();
+    h.cleanup();
+    assert.equal(h.listeners.size, 0);
+    assert.equal(h.shell.children.length, 0);
+  });
+}
+
+test("unrelated fullscreen elements do not take ownership of the CRT canvas", () => {
+  const h = harness();
+  h.document.fullscreenElement = h.other;
+  h.listeners.get("fullscreenchange")();
+  assert.equal(h.canvas.parentNode, h.host);
+  h.cleanup();
+});

--- a/web-prototype/src/RetroHome.jsx
+++ b/web-prototype/src/RetroHome.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { mountFullscreenOverlay } from "../shared/fullscreen-overlay.js";
 import logoFallbackUrl from "../visual/assets/smash-the-weights-logo.png?url";
 import FlameAction from "./FlameAction.jsx";
 import MobileControls from "./MobileControls.jsx";
@@ -202,6 +203,12 @@ function GodRay() {
   );
 }
 
+function CrtViewport() {
+  const hostRef = useRef(null);
+  useLayoutEffect(() => mountFullscreenOverlay(hostRef.current, document), []);
+  return <div ref={hostRef} className="crt-viewport-host" />;
+}
+
 function RuntimeControls() {
   return (
     <>
@@ -216,7 +223,7 @@ function RuntimeControls() {
       </details>
       <details id="crt-tuner" hidden><summary>CRT viewport tuning</summary><div className="crt-tuner-body"><button type="button" data-crt-reset>Reset defaults</button></div></details>
       <canvas id="glove-canvas" />
-      <canvas id="crt-viewport-canvas" aria-hidden="true" />
+      <CrtViewport />
     </>
   );
 }

--- a/web-prototype/src/styles.css
+++ b/web-prototype/src/styles.css
@@ -41,6 +41,9 @@ main { width: min(1600px, calc(100% - 40px)); margin: 0 auto; }
 .create-page .creator-section { flex: 1; }
 .create-retro-screen { background: #000; cursor: auto; }
 .create-retro-screen::before { background: #000; opacity: 1; }
+.crt-viewport-host { display: contents; }
+/* CSS fullscreen stays in the page, above the normal CRT overlay layer. */
+body.is-immersive #crt-viewport-canvas { z-index: 2501; }
 #crt-viewport-canvas {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
Entering fullscreen hides the CRT effect because the game shell enters the browser's fullscreen layer while the overlay stays outside it. Move the existing CRT canvas into the fullscreen shell on entry and restore it on exit, preserving its WebGL context and settings. Also raise the overlay above the game in the CSS immersive fallback.

The overlay uses a dedicated host with cleanup for fullscreen listeners and canvas ownership. Standard and WebKit fullscreen events are supported.

Validation:
- Production build passes.
- All 3 new regression tests pass, covering repeated fullscreen entry/exit, cleanup, and unrelated fullscreen elements.
- Browser visual verification remains pending.


Proof:
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/b33dc5c0-fab9-4219-8404-e75a5944c1c3" />
