### PR TITLE
Enforce fighter retry quotas against stored job state

### DIFF
--- a/web-prototype/server/fighter-jobs.js
+++ b/web-prototype/server/fighter-jobs.js
@@ -1131,34 +1131,14 @@ export function createFighterJobs({
   // limit. Automatic reroll/transient budgets carry over between attempts, so
   // a job can never exceed 1 + manual + automatic worker executions.
   async function retry(id, ownerId) {
-    const job = ownedJob(id, ownerId);
-    if (!job) throw new HttpError(404, "Fighter job not found.");
-    if (ACTIVE_JOB_STATUSES.has(job.status)) throw new HttpError(409, "That fighter is already being generated.");
-    if (job.status === "complete") throw new HttpError(409, "That fighter is already complete.");
-    const manualRetriesAt = job.retry?.manualRetriesAt || [];
-    if (manualRetriesAt.length >= maxManualRetries) {
-      throw new HttpError(429, "This fighter has used all of its retries. Create a new fighter instead.");
-    }
+    let job;
     try {
-      assertQuota(quotaUsage(jobs.values(), job.ownerId, { pending }), limits);
+      job = await jobDatabase.retry(id, ownerId, { quota: limits, maxManualRetries });
     } catch (error) {
       throw httpErrorFrom(error);
     }
-    job.status = "queued";
-    job.stage = "queued";
-    job.stageLabel = workerBusy ? "Waiting for the current fighter" : "Queued to resume";
-    job.progress = 0;
-    job.error = null;
-    job.retry = {
-      automaticCounts: job.retry?.automaticCounts || { moderation: 0, transient: 0 },
-      nextAttemptAt: null,
-      label: null,
-      manualRetriesAt: [...manualRetriesAt, new Date().toISOString()],
-    };
-    job.completedAt = null;
-    job.dispatch = null;
-    job.lease = null;
-    await saveJob(job);
+    jobs.set(job.id, normalizeStoredJob(job));
+    events.emit(job.id, jobSnapshot(job));
     await dispatch(job);
     return publicJob(job);
   }

--- a/web-prototype/server/fighter-jobs.test.js
+++ b/web-prototype/server/fighter-jobs.test.js
@@ -14,6 +14,7 @@ import {
   uploaderToken,
 } from "./fighter-jobs.js";
 import { createTurnstileVerifier } from "./turnstile.js";
+import { prepareRetry } from "./job-database.js";
 
 // Keep the in-process queue from spawning the real pipeline during tests.
 process.env.FIGHTER_WORKER_DISABLED = "1";
@@ -46,6 +47,12 @@ async function harness({ storedJobs = [], moderator = async () => ({ status: "ap
     list: async () => storedJobs,
     insert: async () => {},
     save: async (job) => { saved.push(job); },
+    retry: async (id, ownerId, options) => {
+      const records = new Map([...storedJobs, ...saved].map((job) => [job.id, job]));
+      const job = prepareRetry(records.get(id), ownerId, [...records.values()], options);
+      saved.push(job);
+      return job;
+    },
     watch,
   };
   const objectStore = {

--- a/web-prototype/server/fighter-jobs.test.js
+++ b/web-prototype/server/fighter-jobs.test.js
@@ -14,7 +14,7 @@ import {
   uploaderToken,
 } from "./fighter-jobs.js";
 import { createTurnstileVerifier } from "./turnstile.js";
-import { prepareRetry } from "./job-database.js";
+import { createJobDatabase, prepareRetry } from "./job-database.js";
 
 // Keep the in-process queue from spawning the real pipeline during tests.
 process.env.FIGHTER_WORKER_DISABLED = "1";
@@ -39,11 +39,11 @@ function uploadRequest({ name = "Test Fighter", turnstileToken = null, headers =
   return request;
 }
 
-async function harness({ storedJobs = [], moderator = async () => ({ status: "approved" }), driver = "local", dispatch = async () => ({ executionName: "exec" }), turnstile = null, reservedSlugs = undefined, watch = () => null } = {}) {
+async function harness({ database = null, storedJobs = [], moderator = async () => ({ status: "approved" }), driver = "local", dispatch = async () => ({ executionName: "exec" }), turnstile = null, reservedSlugs = undefined, watch = () => null } = {}) {
   const appRoot = await mkdtemp(path.join(os.tmpdir(), "opensmash-jobs-test-"));
   await mkdir(path.join(appRoot, "data", "fighter-jobs"), { recursive: true });
   const saved = [];
-  const jobDatabase = {
+  const jobDatabase = database || {
     list: async () => storedJobs,
     insert: async () => {},
     save: async (job) => { saved.push(job); },
@@ -76,6 +76,32 @@ async function harness({ storedJobs = [], moderator = async () => ({ status: "ap
 }
 
 const minutesAgo = (minutes) => new Date(Date.now() - minutes * 60_000).toISOString();
+
+test("two API instances with stale caches cannot both dispatch owner retries", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "opensmash-retry-replicas-"));
+  const database = createJobDatabase({ jobsRoot: root });
+  await database.init();
+  const first = storedJob();
+  const second = storedJob({ id: "22222222-2222-2222-2222-222222222222", slug: "second" });
+  await database.insert(first);
+  await database.insert(second);
+  let dispatched = 0;
+  const options = { database, driver: "external", dispatch: async () => ({ executionName: `exec-${++dispatched}` }) };
+  const a = await harness(options);
+  const b = await harness(options);
+  try {
+    await a.jobs.init();
+    await b.jobs.init(); // no watch updates: both caches contain failed jobs
+    await a.jobs.retry(first.id, first.ownerId);
+    await assert.rejects(b.jobs.retry(second.id, second.ownerId), { status: 429 });
+    assert.equal(dispatched, 1);
+    assert.equal((await database.get(second.id)).status, "failed");
+  } finally {
+    await a.cleanup();
+    await b.cleanup();
+    await rm(root, { recursive: true, force: true });
+  }
+});
 
 function storedJob(overrides = {}) {
   return {

--- a/web-prototype/server/job-database.js
+++ b/web-prototype/server/job-database.js
@@ -108,12 +108,12 @@ class LocalJobDatabase {
 
   async insert(job, { quota = null } = {}) {
     return withLocalQuotaLock(this.root, async () => {
-    const existing = await this.list();
-    if (existing.some((candidate) => candidate.slug === job.slug)) {
-      throw duplicateSlugError(job.slug);
-    }
-    if (quota) assertQuota(quotaUsage(existing, job.ownerId), quota);
-    await this.write(job);
+      const existing = await this.list();
+      if (existing.some((candidate) => candidate.slug === job.slug)) {
+        throw duplicateSlugError(job.slug);
+      }
+      if (quota) assertQuota(quotaUsage(existing, job.ownerId), quota);
+      await this.write(job);
     });
   }
 

--- a/web-prototype/server/job-database.js
+++ b/web-prototype/server/job-database.js
@@ -4,6 +4,35 @@ import { randomUUID } from "node:crypto";
 import { ACTIVE_JOB_STATUSES } from "./job-protocol.js";
 import { DAY_MS, assertQuota, quotaUsage } from "./job-quota.js";
 
+export function prepareRetry(job, ownerId, jobs, { quota, maxManualRetries }) {
+  const reject = (status, message) => { throw Object.assign(new Error(message), { status }); };
+  if (!job || job.ownerId !== ownerId) reject(404, "Fighter job not found.");
+  if (ACTIVE_JOB_STATUSES.has(job.status)) reject(409, "That fighter is already being generated.");
+  if (job.status === "complete") reject(409, "That fighter is already complete.");
+  const retries = job.retry?.manualRetriesAt || [];
+  if (retries.length >= maxManualRetries) reject(429, "This fighter has used all of its retries. Create a new fighter instead.");
+  assertQuota(quotaUsage(jobs, ownerId), quota);
+  const now = new Date().toISOString();
+  return {
+    ...job, status: "queued", stage: "queued", stageLabel: "Queued to resume",
+    progress: 0, error: null, completedAt: null, dispatch: null, lease: null,
+    revision: (job.revision || 0) + 1, updatedAt: now,
+    retry: { automaticCounts: job.retry?.automaticCounts || { moderation: 0, transient: 0 },
+      nextAttemptAt: null, label: null, manualRetriesAt: [...retries, now] },
+  };
+}
+
+// Local mode runs in one process, but separate adapters can share a root.
+const localQuotaLocks = new Map();
+async function withLocalQuotaLock(root, run) {
+  const key = path.resolve(root);
+  const previous = localQuotaLocks.get(key) || Promise.resolve();
+  const current = previous.catch(() => {}).then(run);
+  localQuotaLocks.set(key, current);
+  try { return await current; }
+  finally { if (localQuotaLocks.get(key) === current) localQuotaLocks.delete(key); }
+}
+
 function duplicateSlugError(slug) {
   const error = new Error(`A fighter with slug '${slug}' already exists.`);
   error.code = "DUPLICATE_SLUG";
@@ -78,12 +107,23 @@ class LocalJobDatabase {
   }
 
   async insert(job, { quota = null } = {}) {
+    return withLocalQuotaLock(this.root, async () => {
     const existing = await this.list();
     if (existing.some((candidate) => candidate.slug === job.slug)) {
       throw duplicateSlugError(job.slug);
     }
     if (quota) assertQuota(quotaUsage(existing, job.ownerId), quota);
     await this.write(job);
+    });
+  }
+
+  async retry(id, ownerId, options) {
+    return withLocalQuotaLock(this.root, async () => {
+      const jobs = await this.list();
+      const updated = prepareRetry(jobs.find((job) => job.id === id), ownerId, jobs, options);
+      await this.write(updated);
+      return updated;
+    });
   }
 
   async save(job, { executionId = null } = {}) {
@@ -149,6 +189,8 @@ export class FirestoreJobDatabase {
     const jobRef = this.collection.doc(job.id);
     const slugRef = this.collection.firestore.collection(`${this.collectionName}Slugs`).doc(job.slug);
     await this.collection.firestore.runTransaction(async (transaction) => {
+      const guard = this.collection.firestore.collection(`${this.collectionName}Quota`).doc("admission");
+      await transaction.get(guard);
       const slug = await transaction.get(slugRef);
       if (slug.exists) throw duplicateSlugError(job.slug);
       if (quota) {
@@ -176,6 +218,23 @@ export class FirestoreJobDatabase {
       }
       transaction.create(slugRef, { jobId: job.id, createdAt: job.createdAt });
       transaction.create(jobRef, job);
+      transaction.set(guard, { updatedAt: job.updatedAt || job.createdAt });
+    });
+  }
+
+  async retry(id, ownerId, options) {
+    return this.collection.firestore.runTransaction(async (transaction) => {
+      // Share the admission guard with creation so retries cannot race new
+      // uploads (including when an account has no active documents yet).
+      const guard = this.collection.firestore.collection(`${this.collectionName}Quota`).doc("admission");
+      await transaction.get(guard);
+      // Retries must count retries of older jobs too, not only recent creations.
+      const snapshot = await transaction.get(this.collection);
+      const jobs = snapshot.docs.map((document) => document.data());
+      const updated = prepareRetry(jobs.find((job) => job.id === id), ownerId, jobs, options);
+      transaction.set(this.collection.doc(id), updated);
+      transaction.set(guard, { updatedAt: updated.updatedAt });
+      return updated;
     });
   }
 

--- a/web-prototype/server/job-database.test.js
+++ b/web-prototype/server/job-database.test.js
@@ -87,6 +87,7 @@ test("insert enforces the quota against stored jobs", async () => {
 // prove the insert path counts site-wide usage server-side instead of reading
 // every matching document.
 function fakeFirestore(seed) {
+  let transactionTail = Promise.resolve();
   const docs = new Map(seed.map((job) => [job.id, job]));
   const slugs = new Set(seed.map((job) => job.slug));
   const reads = { documents: 0, aggregations: 0 };
@@ -108,7 +109,8 @@ function fakeFirestore(seed) {
     doc: (id) => ({ kind: "doc", id }),
     firestore: {
       collection: (name) => ({ doc: (slug) => ({ kind: name.endsWith("Quota") ? "guard" : "slug", id: slug }) }),
-      runTransaction: async (run) => run({
+      runTransaction: (run) => {
+        const result = transactionTail.then(() => run({
         get: async (target) => {
           if (target.kind === "guard") return { exists: false };
           if (target.kind === "doc") return { exists: docs.has(target.id), data: () => structuredClone(docs.get(target.id)) };
@@ -126,10 +128,69 @@ function fakeFirestore(seed) {
           else docs.set(target.id, value);
         },
         set: (target, value) => { if (target.kind !== "guard") docs.set(target.id, structuredClone(value)); },
-      }),
+        }));
+        transactionTail = result.catch(() => {});
+        return result;
+      },
     },
   };
   return { collection, reads, docs };
+}
+
+for (const driver of ["local", "firestore"]) {
+  async function withRetryDatabase(run) {
+    if (driver === "local") return withDatabase(run);
+    const database = new FirestoreJobDatabase({ collectionName: "jobs" });
+    database.collection = fakeFirestore([]).collection;
+    return run(database);
+  }
+  const options = { quota: { maxActivePerOwner: 1, maxDailyPerOwner: 10,
+    maxGlobalActive: 200, maxGlobalDaily: 5000 }, maxManualRetries: 3 };
+  const failed = (id, ownerId = "owner") => ({ id, slug: id, ownerId, status: "failed",
+    createdAt: new Date(Date.now() - 2 * DAY).toISOString(), revision: 1,
+    retry: { automaticCounts: { moderation: 2, transient: 1 }, manualRetriesAt: [] } });
+  const DAY = 24 * 60 * 60 * 1000;
+
+  test(`[${driver}] concurrent retries admit only one job per owner`, async () => {
+    await withRetryDatabase(async (database) => {
+      await database.insert(failed("one"));
+      await database.insert(failed("two"));
+      const results = await Promise.allSettled([
+        database.retry("one", "owner", options), database.retry("two", "owner", options),
+      ]);
+      assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
+      assert.equal(results.find((result) => result.status === "rejected").reason.reason, "active");
+      const job = results.find((result) => result.status === "fulfilled").value;
+      assert.equal(job.retry.manualRetriesAt.length, 1);
+      assert.deepEqual(job.retry.automaticCounts, { moderation: 2, transient: 1 });
+    });
+  });
+
+  test(`[${driver}] retry cannot overwrite a claimed job or reset its retry budget`, async () => {
+    await withRetryDatabase(async (database) => {
+      await database.insert(failed("one"));
+      await database.retry("one", "owner", options);
+      await database.claim("one", "worker", 60);
+      await assert.rejects(database.retry("one", "owner", options), { status: 409 });
+      const current = driver === "local" ? await database.get("one")
+        : (await database.collection.firestore.runTransaction((tx) => tx.get(database.collection.doc("one")))).data();
+      assert.equal(current.lease.executionId, "worker");
+      assert.equal(current.retry.manualRetriesAt.length, 1);
+    });
+  });
+
+  test(`[${driver}] retry counts recent retries of old jobs toward the global daily limit`, async () => {
+    await withRetryDatabase(async (database) => {
+      const used = failed("used", "other");
+      used.retry.manualRetriesAt = [new Date().toISOString()];
+      await database.insert(used);
+      await database.insert(failed("one"));
+      await assert.rejects(database.retry("one", "owner", {
+        ...options, quota: { ...options.quota, maxGlobalDaily: 1 },
+      }), (error) => error.reason === "globalDaily");
+      await assert.rejects(database.retry("one", "stranger", options), { status: 404 });
+    });
+  });
 }
 
 test("firestore insert counts site-wide usage with aggregations, not document reads", async () => {

--- a/web-prototype/server/job-database.test.js
+++ b/web-prototype/server/job-database.test.js
@@ -107,9 +107,11 @@ function fakeFirestore(seed) {
     ...query([]),
     doc: (id) => ({ kind: "doc", id }),
     firestore: {
-      collection: () => ({ doc: (slug) => ({ kind: "slug", id: slug }) }),
+      collection: (name) => ({ doc: (slug) => ({ kind: name.endsWith("Quota") ? "guard" : "slug", id: slug }) }),
       runTransaction: async (run) => run({
         get: async (target) => {
+          if (target.kind === "guard") return { exists: false };
+          if (target.kind === "doc") return { exists: docs.has(target.id), data: () => structuredClone(docs.get(target.id)) };
           if (target.kind === "slug") return { exists: slugs.has(target.id) };
           const rows = [...docs.values()].filter((job) => matches(job, target.filters));
           if (target.kind === "aggregate") {
@@ -123,6 +125,7 @@ function fakeFirestore(seed) {
           if (target.kind === "slug") slugs.add(target.id);
           else docs.set(target.id, value);
         },
+        set: (target, value) => { if (target.kind !== "guard") docs.set(target.id, structuredClone(value)); },
       }),
     },
   };


### PR DESCRIPTION
Retrying failed fighters on two API replicas can exceed the account's active-job limit: each replica checks its cached failed jobs and then unconditionally saves a queued job. A stale retry can also replace newer worker state.

Move retry admission into the job database. The stored job's owner, status, retry budget and current quota usage are checked together with the queued-state write. Firestore admission shares a transaction guard with new-job insertion; local admission serializes inserts and retries within the server process. The API dispatches only after admission succeeds and preserves the existing automatic retry budget.

Validation: 32 targeted database/job tests pass, including two API instances with stale caches, competing retries, claimed-job protection, ownership and recent retries of older jobs. Firestore behavior is covered with a transactional stand-in, not a live Firestore emulator. The full web suite retains the pre-existing OG fixture failure addressed independently in fix/og-hit-test-fixture.

Tradeoff: Firestore retry admission reads the job collection to count rolling retry history accurately. This increases retry read cost as job history grows; new-job admission retains its aggregate queries. The shared admission document serializes creation/retry admission. Local locking is process-local, matching the single-process local deployment model.
