### PR TITLE
Preserve working rosters when character rebuilds fail

### DIFF
--- a/targets/characters.py
+++ b/targets/characters.py
@@ -1,5 +1,6 @@
 """Resolve website characters and stage an offline BattleShip roster (stdlib only)."""
 import argparse
+import copy
 from concurrent.futures import ThreadPoolExecutor
 import gzip
 import hashlib
@@ -14,6 +15,7 @@ import struct
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 
 FIGHTERS = ['mario', 'fox', 'donkey', 'samus', 'luigi', 'link', 'yoshi', 'captain', 'kirby', 'pikachu', 'purin', 'ness']
 # Visual tile order used by the native character-select screen.
@@ -291,12 +293,34 @@ def assign_rom(available, preferred):
 
 
 def prepare(args):
+    output = args.output.resolve()
+    # Resolve first: invalid selections must not create an output directory.
     characters = resolve(args.catalog, args.site, args.characters, args.character_url)
     if args.target == 'rom' and len(characters) > 12:
         raise ValueError(f'Catalog has {len(characters)} characters; this ROM exporter has 12 fixed slots, not runtime pagination. '
                          'Select up to 12 with --characters slug1,slug2 (private links count toward this limit).')
+    output.mkdir(parents=True, exist_ok=True)
+    generation = uuid.uuid4().hex
+    asset_prefix = Path('characters') / generation
+    with tempfile.TemporaryDirectory(prefix='.roster-staging-', dir=output) as temporary:
+        staged_args = copy.copy(args)
+        staged_args.output = Path(temporary)
+        count = stage_roster(staged_args, characters, output/'character-cache', asset_prefix)
+        # Old roster entries keep referring to their original generation.
+        # Moving within the output filesystem and replacing the entrypoint
+        # last avoids exposing a partially validated/replaced roster.
+        (output/'characters').mkdir(exist_ok=True)
+        os.replace(staged_args.output/asset_prefix, output/asset_prefix)
+        entrypoint = 'roster.txt' if args.target == 'native' else 'loadout.json'
+        for name in ('play.py', 'Play.command', 'Play.bat', 'characters.json', entrypoint):
+            staged = staged_args.output/name
+            if staged.exists():
+                os.replace(staged, output/name)
+    print(f'Prepared {count} characters' + (f' on {(count+11)//12} custom pages (+ vanilla)' if args.target == 'native' else ''), flush=True)
+
+
+def stage_roster(args, characters, cache, asset_prefix):
     output = args.output.resolve()
-    cache = output / 'character-cache'
     cache.mkdir(parents=True, exist_ok=True)
     print(f'Preparing {len(characters)} characters for {args.target}…', flush=True)
     # Files are cached on disk; retain only one fighter per worker in memory.
@@ -319,7 +343,7 @@ def prepare(args):
         assignments = assign_rom(available, [c['fkind'] for c in characters])
     rows, report, loadout = [], [], []
     for i, c in enumerate(characters):
-        folder = output / 'characters' / c['slug']
+        folder = output / asset_prefix / c['slug']
         folder.mkdir(parents=True, exist_ok=True)
         data = cached_asset(c['bundleUrl'], cache)
         fk = assignments[i] if args.target == 'rom' else c['fkind']
@@ -361,7 +385,7 @@ def prepare(args):
     else:
         (output/'loadout.json').write_text(json.dumps(loadout, indent=2)+'\n')
     (output/'characters.json').write_text(json.dumps(dict(target=args.target, count=len(report), characters=report), indent=2)+'\n')
-    print(f'Prepared {len(report)} characters' + (f' on {(len(report)+11)//12} custom pages (+ vanilla)' if args.target == 'native' else ''), flush=True)
+    return len(report)
 
 
 LAUNCHER = '''#!/usr/bin/env python3

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -49,6 +49,46 @@ def custom_manifest():
 
 
 class CharacterTests(unittest.TestCase):
+    def test_failed_rebuild_preserves_existing_roster_and_assets(self):
+        for target in ('native', 'rom'):
+            with self.subTest(target=target), tempfile.TemporaryDirectory() as tmp:
+                output = Path(tmp)
+                args = type('Args', (), dict(target=target, output=output, catalog='unused',
+                    site='https://assets.test', characters=['one'], character_url=[]))()
+                with patch.object(c, 'resolve', return_value=[row('one', short='ONE')]), \
+                        patch.object(c, 'cached_asset', return_value=bundle()), \
+                        contextlib.redirect_stdout(io.StringIO()):
+                    c.prepare(args)
+                original = {p.relative_to(output): p.read_bytes() for p in output.rglob('*')
+                            if p.is_file() and 'character-cache' not in p.parts}
+                changed = bytearray(bundle())
+                changed[16:18] = b'\x00\x01'
+                with patch.object(c, 'resolve', return_value=[row('one', short='ONE', uiUrl='https://assets.test/bad')]), \
+                        patch.object(c, 'cached_asset', side_effect=lambda url, cache: b'bad UI' if url.endswith('/bad') else bytes(changed)), \
+                        contextlib.redirect_stdout(io.StringIO()):
+                    with self.assertRaisesRegex(ValueError, 'invalid uiUrl'):
+                        c.prepare(args)
+                self.assertEqual(original, {p.relative_to(output): p.read_bytes() for p in output.rglob('*')
+                                          if p.is_file() and 'character-cache' not in p.parts})
+                self.assertFalse(list(output.glob('.roster-staging-*')))
+
+    def test_successful_rebuild_switches_roster_without_overwriting_old_assets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            args = type('Args', (), dict(target='native', output=output, catalog='unused',
+                site='https://assets.test', characters=['one'], character_url=[]))()
+            with patch.object(c, 'resolve', return_value=[row('one', short='ONE')]), \
+                    patch.object(c, 'cached_asset', return_value=bundle()), \
+                    contextlib.redirect_stdout(io.StringIO()):
+                c.prepare(args)
+                old_mesh = output/(output/'roster.txt').read_text().split('|')[2]
+                old_bytes = old_mesh.read_bytes()
+                c.prepare(args)
+            new_mesh = output/(output/'roster.txt').read_text().split('|')[2]
+            self.assertNotEqual(old_mesh, new_mesh)
+            self.assertEqual(old_mesh.read_bytes(), old_bytes)
+            self.assertEqual(new_mesh.read_bytes(), old_bytes)
+
     def test_private_build_link_and_unicode(self):
         raw=row('mine', ownerId='must-not-be-copied')
         raw['name']='私の fighter'


### PR DESCRIPTION
A rebuild currently overwrites mesh files referenced by the working roster before validating companion UI/audio assets. If validation fails, the old roster remains but its files have already changed.

Stage the complete native or ROM roster in a temporary directory, including validation and launcher generation. Publish assets into a new generation directory and atomically replace roster.txt or loadout.json last. Existing roster references continue to resolve to their original assets throughout staging and publication.

Validation: all 33 build/import tests pass. Regression coverage verifies failed native and ROM rebuilds preserve existing files byte-for-byte and remove staging directories; successful native rebuilds switch asset references without overwriting the previous generation.

Previous asset generations are intentionally retained, so repeated successful rebuilds use additional disk space. A filesystem failure during publication can leave an unreferenced generation, but cannot overwrite assets used by the previous roster. The roster entrypoint is atomic; auxiliary report/launcher files are replaced individually.
