### PR TITLE
Fix occupied fighter fixtures in OG hit-testing tests

### DIFF
--- a/web-prototype/shared/og-studio.test.js
+++ b/web-prototype/shared/og-studio.test.js
@@ -47,11 +47,17 @@ test("fighter frames apply zoom and direct-manipulation offsets", () => {
 });
 
 test("transformed fighter hit testing follows the visible selection frame", () => {
-  const placements = OG_ROSTER_SLOTS.map((slot) => ({ zoom: slot.zoom, offsetX: 20, offsetY: 0 }));
+  const placements = OG_ROSTER_SLOTS.map((slot) => ({ slug: slot.id, zoom: slot.zoom, offsetX: 20, offsetY: 0 }));
   const frame = fighterFrame(OG_ROSTER_SLOTS.at(-1), placements.at(-1));
 
   assert.equal(fighterSlotAtPoint(frame.x + frame.width / 2, frame.y + frame.height / 2, placements), placements.length - 1);
   assert.equal(fighterSlotAtPoint(-100, -100, placements), -1);
+});
+
+test("empty fighter positions cannot be selected", () => {
+  const placements = OG_ROSTER_SLOTS.map((slot) => ({ slug: null, zoom: slot.zoom, offsetX: 0, offsetY: 0 }));
+  const frame = fighterFrame(OG_ROSTER_SLOTS.at(-1), placements.at(-1));
+  assert.equal(fighterSlotAtPoint(frame.x + frame.width / 2, frame.y + frame.height / 2, placements), -1);
 });
 
 test("body choices include Mario and only variants present in the fighter bundle", () => {


### PR DESCRIPTION
The transformed-fighter hit-testing test creates placements without slugs. Hit testing treats those placements as empty positions and correctly returns -1, while the test expects a selectable fighter.

Give the occupied test placements character identities and add explicit coverage that empty positions remain unselectable. No application behavior changes.

Validation: all 236 web tests pass using node --test server/*.test.js shared/*.test.js. Tests were run directly because this checkout's existing pnpm workspace configuration is rejected by the installed pnpm version.
